### PR TITLE
Issue #18: Dollar Sign Not Aligned

### DIFF
--- a/pages/garage.js
+++ b/pages/garage.js
@@ -559,7 +559,7 @@ const Garage = () => {
                         <h2>Set Sale Price</h2>
                         <label style={{color: "orange", fontWeight: "bold"}} htmlFor="listing_price">Sale Price</label>
                         <div style={{display: "flex", alignItems: 'center'}}>
-                            <h3 style={{color: 'orange', display: 'flex', alignItems: 'center', justifyContent: 'center'}}>$</h3>
+                            <h3 style={{color: 'orange', display: 'flex', alignItems: 'center', justifyContent: 'center', paddingBottom:'10px'}}>$</h3>
                             <Input
                             id="listing_price"
                             type="number"


### PR DESCRIPTION
Add padding to $ to match Sale Price input's padding & margin
<img width="650" alt="Screen Shot 2025-03-27 at 10 22 05 PM" src="https://github.com/user-attachments/assets/50b57c0f-0ad8-4b0f-9262-c6887adfd7fc" />


https://github.com/PL8M8/web/issues/18