### PR TITLE
Bug Fix Issue #52

### DIFF
--- a/components/Navbar.js
+++ b/components/Navbar.js
@@ -284,7 +284,19 @@ const Navbar = ({ extraComponents }) => {
     }, [router]);
 
     useEffect(() => {
-        const currentPath = router.pathname;
+        // Utility: convert a dynamic path like "/profile/[id]" into a regex
+        const pathToRegex = (path) => {
+        const escaped = path
+            .replace(/\//g, "\\/")
+            .replace(/\[.*?\]/g, "[^/]+"); // replace [id] with wildcard
+
+        return new RegExp(`^${escaped}(\\/.*)?$`); // match full path or subroutes
+        };
+
+        const currentPath = loggedInNavLinks
+            .filter(link => pathToRegex(link.path).test(router.pathname))
+            .sort((a, b) => b.path.length - a.path.length)[0]?.path;
+
         const active = isSignedIn ? (
                 loggedInNavLinks.some(link => link.path === currentPath)
                 ? loggedInNavLinks.find(link => link.path === currentPath).name


### PR DESCRIPTION
use regex to match base path for highlighted (current) tab
*** NOTE: Does not currently work for Buy and Sell, as base "/" is different when click on vehicle in Buy and Sell "/vehicle/[id]" (see image 4) 


<img width="1056" alt="Screen Shot 2025-05-16 at 4 02 22 PM" src="https://github.com/user-attachments/assets/2368bfd0-2614-4bb2-b911-ee53a74d8037" />
<img width="1136" alt="Screen Shot 2025-05-16 at 4 02 25 PM" src="https://github.com/user-attachments/assets/041fba4d-a271-4a54-9df3-ebae0e296526" />
<img width="960" alt="Screen Shot 2025-05-16 at 4 02 31 PM" src="https://github.com/user-attachments/assets/e2b8d555-13b4-4df0-b1c0-6ec07bb52183" />
<img width="987" alt="Screen Shot 2025-05-16 at 4 02 34 PM" src="https://github.com/user-attachments/assets/f3a3ab9a-36c3-4024-99f9-ce8e6661c105" />


